### PR TITLE
[BUG] ロゴの"42東京"のウィンドウを背面にする #10

### DIFF
--- a/src/components/layout/background.tsx
+++ b/src/components/layout/background.tsx
@@ -7,7 +7,7 @@ interface BackgroundProps {
 
 export const Background: React.FC<BackgroundProps> = ({ children }) => {
     return (
-        <Box bg="gray.700" minHeight="100vh" position="relative">
+        <Box bg="gray.700" minHeight="100vh" position="relative" zIndex={-1}>
             {children}
         </Box>
     );

--- a/src/components/layout/mobileContainer.tsx
+++ b/src/components/layout/mobileContainer.tsx
@@ -3,8 +3,8 @@ import { Box } from '@chakra-ui/react';
 
 export const MobileContainer: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     return (
-        <Box bg="white" position="relative" height="100vh">
-            <Box position="fixed" top={0} bottom={0} left={0} right={0} bg="white">
+        <Box bg="black" position="relative" height="100vh">
+            <Box position="fixed" top={0} bottom={0} left={0} right={0} bg="black">
                 <Box
                     position="absolute"
                     top="50%"

--- a/src/components/layout/mobileContainer.tsx
+++ b/src/components/layout/mobileContainer.tsx
@@ -12,7 +12,8 @@ export const MobileContainer: React.FC<{ children: React.ReactNode }> = ({ child
                     transform="translate(-50%, -50%)"
                     maxWidth="480px"
                     width="100%"
-                    height="100%"
+                    // useMediaQueryが使用できなかっため、CSSメディアクエリで代用
+                    height={{ base: '100%', md: '56.25%' }}
                     overflow="hidden"
                 >
                     {children}

--- a/src/components/layout/transparentImage.tsx
+++ b/src/components/layout/transparentImage.tsx
@@ -14,6 +14,7 @@ export const LogoImage = () => {
             height="auto"
             opacity={0.5}
             filter="invert(100%)"
+            zIndex={-1}
         />
     );
 };


### PR DESCRIPTION
z-indexで背面方向に下げました！

こちらも #11同様に送金画面のstep を2（検索（確認））にすると確認しやすいかと思います。